### PR TITLE
Request all data at once

### DIFF
--- a/components/tianpower_bms_ble/tianpower_bms_ble.cpp
+++ b/components/tianpower_bms_ble/tianpower_bms_ble.cpp
@@ -207,15 +207,9 @@ void TianpowerBmsBle::update() {
     return;
   }
 
-  // Loop through all commands if connected
-  if (this->next_command_ != TIANPOWER_COMMAND_QUEUE_SIZE) {
-    ESP_LOGW(TAG,
-             "Command queue (%d of %d) was not completely processed. "
-             "Please increase the update_interval if you see this warning frequently",
-             this->next_command_ + 1, TIANPOWER_COMMAND_QUEUE_SIZE);
+  for (uint8_t command : TIANPOWER_COMMAND_QUEUE) {
+    this->send_command_(command);
   }
-  this->next_command_ = 0;
-  this->send_command_(TIANPOWER_COMMAND_QUEUE[this->next_command_++ % TIANPOWER_COMMAND_QUEUE_SIZE]);
 }
 
 void TianpowerBmsBle::on_tianpower_bms_ble_data(const uint8_t &handle, const std::vector<uint8_t> &data) {
@@ -261,11 +255,6 @@ void TianpowerBmsBle::on_tianpower_bms_ble_data(const uint8_t &handle, const std
     default:
       ESP_LOGW(TAG, "Unhandled response received (frame_type 0x%02X): %s", frame_type,
                format_hex_pretty(&data.front(), data.size()).c_str());
-  }
-
-  // Send next command after each received frame
-  if (this->next_command_ < TIANPOWER_COMMAND_QUEUE_SIZE) {
-    this->send_command_(TIANPOWER_COMMAND_QUEUE[this->next_command_++ % TIANPOWER_COMMAND_QUEUE_SIZE]);
   }
 }
 

--- a/components/tianpower_bms_ble/tianpower_bms_ble.h
+++ b/components/tianpower_bms_ble/tianpower_bms_ble.h
@@ -172,7 +172,6 @@ class TianpowerBmsBle : public esphome::ble_client::BLEClientNode, public Pollin
   uint16_t char_notify_handle_;
   uint16_t char_notify2_handle_;
   uint16_t char_command_handle_;
-  uint8_t next_command_{5};
 
   float min_cell_voltage_{100.0f};
   float max_cell_voltage_{-100.0f};


### PR DESCRIPTION
See #22

Use

```
substitutions:
  name: tianpower-bms-ble
  device_description: "Monitor a Tianpower Battery Management System via BLE"
  external_components_source: github://syssi/esphome-tianpower-bms@req-on-block
```

instead of

```
substitutions:
  name: tianpower-bms-ble
  device_description: "Monitor a Tianpower Battery Management System via BLE"
  external_components_source: github://syssi/esphome-tianpower-bms@main
```