### PR TITLE
Drop ADDR_STR compat macro, bump minimum ESPHome version to 2025.12

### DIFF
--- a/components/tianpower_bms_ble/__init__.py
+++ b/components/tianpower_bms_ble/__init__.py
@@ -22,7 +22,7 @@ TIANPOWER_BMS_BLE_COMPONENT_SCHEMA = cv.Schema(
 )
 
 CONFIG_SCHEMA = cv.All(
-    cv.require_esphome_version(2024, 12, 0),
+    cv.require_esphome_version(2025, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(TianpowerBmsBle),

--- a/components/tianpower_bms_ble/tianpower_bms_ble.cpp
+++ b/components/tianpower_bms_ble/tianpower_bms_ble.cpp
@@ -1,13 +1,6 @@
 #include "tianpower_bms_ble.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
-#include "esphome/core/version.h"
-
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 12, 0)
-#define ADDR_STR(x) x
-#else
-#define ADDR_STR(x) (x).c_str()
-#endif
 
 namespace esphome {
 namespace tianpower_bms_ble {
@@ -162,7 +155,7 @@ void TianpowerBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
           this->parent_->get_characteristic(TIANPOWER_BMS_SERVICE_UUID, TIANPOWER_BMS_NOTIFY_CHARACTERISTIC_UUID);
       if (char_notify == nullptr) {
         ESP_LOGE(TAG, "[%s] No notify service found at device, not an Tianpower BMS..?",
-                 ADDR_STR(this->parent_->address_str()));
+                 this->parent_->address_str());
         break;
       }
       this->char_notify_handle_ = char_notify->handle;
@@ -178,7 +171,7 @@ void TianpowerBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
       //          TIANPOWER_BMS_NOTIFY2_CHARACTERISTIC_UUID);
       //      if (char_notify2 == nullptr) {
       //        ESP_LOGE(TAG, "[%s] No notify service found at device, not an Tianpower BMS..?",
-      //                 ADDR_STR(this->parent_->address_str()).c_str());
+      //                 this->parent_->address_str().c_str());
       //        break;
       //      }
       //      this->char_notify2_handle_ = char_notify->handle;
@@ -193,7 +186,7 @@ void TianpowerBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
           this->parent_->get_characteristic(TIANPOWER_BMS_SERVICE_UUID, TIANPOWER_BMS_CONTROL_CHARACTERISTIC_UUID);
       if (char_command == nullptr) {
         ESP_LOGE(TAG, "[%s] No control service found at device, not an BASEN BMS..?",
-                 ADDR_STR(this->parent_->address_str()));
+                 this->parent_->address_str());
         break;
       }
       this->char_command_handle_ = char_command->handle;
@@ -223,7 +216,7 @@ void TianpowerBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
 void TianpowerBmsBle::update() {
   this->track_online_status_();
   if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    ESP_LOGW(TAG, "[%s] Not connected", ADDR_STR(this->parent_->address_str()));
+    ESP_LOGW(TAG, "[%s] Not connected", this->parent_->address_str());
     return;
   }
 
@@ -692,7 +685,7 @@ bool TianpowerBmsBle::send_command_(uint8_t function) {
                                sizeof(frame), frame, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
 
   if (status) {
-    ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", ADDR_STR(this->parent_->address_str()), status);
+    ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str(), status);
   }
 
   return (status == 0);


### PR DESCRIPTION
## Problem

The `ADDR_STR` preprocessor macro was introduced to paper over a breaking change in ESPHome 2025.12 where `address_str()` changed its return type from `std::string` to `const char *`. The macro selected between `.c_str()` and a direct pass-through at compile time.

Now that the minimum required ESPHome version is being moved to 2025.12, the old code path is unreachable and the macro can be removed entirely.

## Fix

- Bump `require_esphome_version` from `(2024, 12, 0)` to `(2025, 12, 0)` in `__init__.py`.
- Remove the `#include "esphome/core/version.h"`, the `#if / #define / #endif` block, and all four `ADDR_STR(...)` call-sites in `tianpower_bms_ble.cpp`, replacing them with direct `this->parent_->address_str()` calls.