### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/tianpower_bms_ble/tianpower_bms_ble.cpp
+++ b/components/tianpower_bms_ble/tianpower_bms_ble.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace tianpower_bms_ble {
+namespace esphome::tianpower_bms_ble {
 
 static const char *const TAG = "tianpower_bms_ble";
 
@@ -736,5 +735,4 @@ std::string TianpowerBmsBle::bitmask_to_string_(const char *const messages[], co
   return values;
 }
 
-}  // namespace tianpower_bms_ble
-}  // namespace esphome
+}  // namespace esphome::tianpower_bms_ble

--- a/components/tianpower_bms_ble/tianpower_bms_ble.h
+++ b/components/tianpower_bms_ble/tianpower_bms_ble.h
@@ -12,8 +12,7 @@
 namespace espbt = esphome::esp32_ble_tracker;
 #endif
 
-namespace esphome {
-namespace tianpower_bms_ble {
+namespace esphome::tianpower_bms_ble {
 
 class TianpowerBmsBle :
 #ifdef USE_ESP32
@@ -226,5 +225,4 @@ class TianpowerBmsBle :
   bool check_bit_(uint16_t mask, uint16_t flag) { return (mask & flag) == flag; }
 };
 
-}  // namespace tianpower_bms_ble
-}  // namespace esphome
+}  // namespace esphome::tianpower_bms_ble


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.